### PR TITLE
Fixes #342

### DIFF
--- a/shoppingfluxexport.php
+++ b/shoppingfluxexport.php
@@ -229,6 +229,7 @@ class ShoppingFluxExport extends Module
                 !Configuration::deleteByName('SHOPPING_FLUX_XML_SHOP_ID') ||
                 !Configuration::deleteByName('SHOPPING_FLUX_CRON_TIME') ||
                 !$this->uninstallCustomConfiguration(['SHOPPING_FLUX_CRON_TIME']) ||
+                !$this->uninstallCustomConfiguration(['SHOPPING_FLUX_TOKEN']) ||
                 !parent::uninstall()) {
             return false;
         }


### PR DESCRIPTION
# Fixes #342

## Changes made

usage of uninstallCustomConfiguration() to remove composed keys from SHOPPING_FLUX_TOKEN

